### PR TITLE
Fixed the Invalid or Expired Verification Token After Verifying Email for Admin User Issue

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -65,13 +65,12 @@ class UserService:
             new_user.nickname = new_nickname
             logger.info(f"User Role: {new_user.role}")
             user_count = await cls.count(session)
-            new_user.role = UserRole.ADMIN if user_count == 0 else UserRole.ANONYMOUS            
+
+            new_user.role = UserRole.ADMIN if user_count == 0 else UserRole.ANONYMOUS
             if new_user.role == UserRole.ADMIN:
                 new_user.email_verified = True
-
-            else:
-                new_user.verification_token = generate_verification_token()
-
+            
+            new_user.verification_token = generate_verification_token()
             session.add(new_user)
             await session.commit()
             await email_service.send_verification_email(new_user)
@@ -170,7 +169,10 @@ class UserService:
         if user and user.verification_token == token:
             user.email_verified = True
             user.verification_token = None  # Clear the token once used
-            user.role = UserRole.AUTHENTICATED
+
+            if user.role == UserRole.ANONYMOUS:
+                user.role = UserRole.AUTHENTICATED
+
             session.add(user)
             await session.commit()
             return True


### PR DESCRIPTION
Modified app/services/user_service.py to generate a verification token for all types of user roles (ADMIN, MANAGER, AUTHENTICATED, and ANONYMOUS), and change a user role to AUTHENTICATED only if the user's initial role was ANONYMOUS.