### PR TITLE
Fixed the Null Values Are Returned for Some User Fields Instead of What Was Specified After Creating a New User Issue

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -161,7 +161,10 @@ async def create_user(user: UserCreate, request: Request, db: AsyncSession = Dep
         last_login_at=created_user.last_login_at,
         created_at=created_user.created_at,
         updated_at=created_user.updated_at,
-        links=create_user_links(created_user.id, request)
+        links=create_user_links(created_user.id, request),
+        linkedin_profile_url=created_user.linkedin_profile_url,
+        github_profile_url=created_user.github_profile_url,
+        is_professional=created_user.is_professional
     )
 
 

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -190,3 +190,12 @@ async def test_list_users_unauthorized(async_client, user_token):
         headers={"Authorization": f"Bearer {user_token}"}
     )
     assert response.status_code == 403  # Forbidden, as expected for regular user
+
+# Test authorizing the user admin login
+@pytest.mark.asyncio
+async def test_authorize_user_admin_login(async_client, admin_token):
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    # Login and get the access token
+    token_response = await async_client.post("/login", headers=headers)
+    assert token_response.status_code == 307


### PR DESCRIPTION
Modified app/routers/user_routes.py by adding the linkedin_profile_url, the github_profile_url, and the is_professional fields to the UserResponse model_construct that is being returned by the create_user function.