### PR TITLE
Fixed the Incorrect HTTP Status Codes Are Returned When Inputting Invalid Values for Skip and Limit Integers to Get a List of Users as an ADMIN or MANAGER Issue

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -176,6 +176,13 @@ async def list_users(
     db: AsyncSession = Depends(get_db),
     current_user: dict = Depends(require_role(["ADMIN", "MANAGER"]))
 ):
+    
+    if skip < 0:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"The Skip Integer value {skip} cannot be less than 0")
+    
+    if limit < 1:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"The Limit Integer value {limit} cannot be less than 1")
+
     total_users = await UserService.count(db)
     users = await UserService.list_users(db, skip, limit)
 

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -210,7 +210,7 @@ async def test_listing_users_as_admin_or_manager_after_inputing_invalid_skip_int
     response = await async_client.get(url=url, params=parameters, headers=headers)
 
     assert response.status_code == 500
-    assert response.json()["detail"] == f"The Skip Integer value {str(parameters["skip"])} cannot be less than 0"
+    assert response.json()["detail"] == "The Skip Integer value -1 cannot be less than 0"
 
 # Test listing users as an ADMIN or a MANAGER after inputing an invalid Limit Integer value
 @pytest.mark.asyncio
@@ -222,4 +222,4 @@ async def test_listing_users_as_admin_or_manager_after_inputing_invalid_limit_in
     response = await async_client.get(url=url, params=parameters, headers=headers)
 
     assert response.status_code == 500
-    assert response.json()["detail"] == f"The Limit Integer value {str(parameters["limit"])} cannot be less than 1"
+    assert response.json()["detail"] == "The Limit Integer value 0 cannot be less than 1"

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -199,3 +199,27 @@ async def test_authorize_user_admin_login(async_client, admin_token):
     # Login and get the access token
     token_response = await async_client.post("/login", headers=headers)
     assert token_response.status_code == 307
+
+# Test listing users as an ADMIN or a MANAGER after inputing an invalid Skip Integer value
+@pytest.mark.asyncio
+async def test_listing_users_as_admin_or_manager_after_inputing_invalid_skip_integer_value(async_client, admin_token):
+    url = "/users/"
+    parameters = {"skip": -1}
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    response = await async_client.get(url=url, params=parameters, headers=headers)
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == f"The Skip Integer value {parameters["skip"]} cannot be less than 0"
+
+# Test listing users as an ADMIN or a MANAGER after inputing an invalid Limit Integer value
+@pytest.mark.asyncio
+async def test_listing_users_as_admin_or_manager_after_inputing_invalid_limit_integer_value(async_client, admin_token):
+    url = "/users/"
+    parameters = {"limit": 0}
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    response = await async_client.get(url=url, params=parameters, headers=headers)
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == f"The Limit Integer value {parameters["limit"]} cannot be less than 1"

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -210,7 +210,7 @@ async def test_listing_users_as_admin_or_manager_after_inputing_invalid_skip_int
     response = await async_client.get(url=url, params=parameters, headers=headers)
 
     assert response.status_code == 500
-    assert response.json()["detail"] == f"The Skip Integer value {parameters["skip"]} cannot be less than 0"
+    assert response.json()["detail"] == f"The Skip Integer value {str(parameters["skip"])} cannot be less than 0"
 
 # Test listing users as an ADMIN or a MANAGER after inputing an invalid Limit Integer value
 @pytest.mark.asyncio
@@ -222,4 +222,4 @@ async def test_listing_users_as_admin_or_manager_after_inputing_invalid_limit_in
     response = await async_client.get(url=url, params=parameters, headers=headers)
 
     assert response.status_code == 500
-    assert response.json()["detail"] == f"The Limit Integer value {parameters["limit"]} cannot be less than 1"
+    assert response.json()["detail"] == f"The Limit Integer value {str(parameters["limit"])} cannot be less than 1"


### PR DESCRIPTION
Modified app/routers/user_routes.py where the list_users function now contains an if statement to check if the Skip Integer value is less than 0 and if the condition is true, an HTTP Status Code of 500 (INTERNAL SERVER ERROR) is returned along with a detail message. The function also now contains another if statement to check if the Limit Integer value is less than 1 and if the condition is true, an HTTP Status Code of 500 (INTERNAL SERVER ERROR) is returned along with a detail message.